### PR TITLE
Removed DispatchQueue and followed clean code practice.

### DIFF
--- a/MVVM-DesignPattern.xcodeproj/project.pbxproj
+++ b/MVVM-DesignPattern.xcodeproj/project.pbxproj
@@ -63,12 +63,12 @@
 				DC64411823AE13C0004A063A /* AppDelegate.swift */,
 				DC64411A23AE13C0004A063A /* SceneDelegate.swift */,
 				DC64411C23AE13C1004A063A /* ViewController.swift */,
+				DC9EF6BB23AF4B820095CF35 /* AuthenticationVM.swift */,
 				DC9EF6B923AF4B340095CF35 /* User.swift */,
 				DC64411E23AE13C1004A063A /* Main.storyboard */,
 				DC64412123AE13C2004A063A /* Assets.xcassets */,
 				DC64412323AE13C2004A063A /* LaunchScreen.storyboard */,
 				DC64412623AE13C2004A063A /* Info.plist */,
-				DC9EF6BB23AF4B820095CF35 /* AuthenticationVM.swift */,
 			);
 			path = "MVVM-DesignPattern";
 			sourceTree = "<group>";

--- a/MVVM-DesignPattern/AuthenticationVM.swift
+++ b/MVVM-DesignPattern/AuthenticationVM.swift
@@ -11,14 +11,17 @@ import Foundation
 class AuthenticationVM: NSObject {
     var user: User!
     
-    var username: String {return user.userName}
-    var email: String {return user.email}
+    var username: String {
+        return user.userName
+    }
+    var email: String {
+        return user.email
+    }
     
     typealias authenticationLoginCallBack = (_ status:Bool, _ message:String) -> Void
     var loginCallback:authenticationLoginCallBack?
     
     func authenticateUserWith(_ username:String, andPassword password:String) {
-        DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 0.2) {
             if username.count  != 0 {
                 if password.count != 0 {
                     self.verifyUserWith(username, andPassword: password)
@@ -30,8 +33,6 @@ class AuthenticationVM: NSObject {
                 // username empty
                 self.loginCallback?(false, "Username should not be empty")
             }
-        }
-        
     }
     
     
@@ -50,6 +51,4 @@ class AuthenticationVM: NSObject {
     func loginCompletionHandler(callBack: @escaping authenticationLoginCallBack) {
         self.loginCallback = callBack
     }
-    
-    
 }

--- a/MVVM-DesignPattern/ViewController.swift
+++ b/MVVM-DesignPattern/ViewController.swift
@@ -28,20 +28,18 @@ class ViewController: UIViewController {
         guard let userName = self.txtUserName.text else {return}
         guard let password = self.txtPassword.text else {return}
         
-        authenticationVM.authenticateUserWith(userName, andPassword: password)
         authenticationVM.loginCompletionHandler { [weak self] (status, message) in
             guard let self = self else {return}
             if status {
-                self.lblMessage.text = "Logged in with username == \(self.authenticationVM.username) and email == \(self.authenticationVM.email)"
+                self.lblMessage.text = "Logged in with username = \(self.authenticationVM.username) and email = \(self.authenticationVM.email)"
                 self.lblMessage.isHidden = false
             } else {
                 self.lblMessage.text = message
                 self.lblMessage.isHidden = false
             }
         }
-        
+        authenticationVM.authenticateUserWith(userName, andPassword: password)
     }
-
 }
 
 


### PR DESCRIPTION
**AuthenticationVM:**			
1. Not required Base class NSObject.
2. Removed _DispatchQueue_ for waiting 0.2 seconds every time while _authenticateUserWith_ function call.

**ViewController:**
3. Called _authenticateUserWith_ function after _loginCompletionHandler_, so _loginCallback_ variable has value (initially it was nil when tap on login button, after launch app, that's why we used DispatchQueue)